### PR TITLE
[Fix]: Change global position modal to fixed

### DIFF
--- a/src/components/CookieComply.vue
+++ b/src/components/CookieComply.vue
@@ -107,7 +107,7 @@ export default {
   display: grid;
   grid-gap: var(--spacing-lg);
   grid-template-columns: 1fr minmax(35%, 40%);
-  position: absolute;
+  position: fixed;
   bottom: var(--spacing-sm);
   left: var(--spacing-sm);
   right: var(--spacing-sm);

--- a/src/components/CookieComplyModal.vue
+++ b/src/components/CookieComplyModal.vue
@@ -87,7 +87,7 @@ export default {
 <style>
 .cookie-comply__modal {
   display: table;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   height: 100%;


### PR DESCRIPTION
Hi, I was using your library and ran into a problem. I have solved it in my personal project, but so that more people can benefit from it I open this pull request.  I hope not to bother you 🙏 .

**Problem detected**
When you scroll on a web with a higher height than the screen the cookie warning modal does not stay at the bottom.

Screenshot normal modal:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/9319491/222006869-3f0b0c4b-5945-4987-a887-a2990b9fe93e.png">
Screenshot settings modal:
<img width="721" alt="image" src="https://user-images.githubusercontent.com/9319491/222008818-6854b934-2c47-46b0-b3c0-92d0c5af8e69.png">

**Proposed solution**
Change the `position` from `absolute` to `fixed` at main class `.cookie-comply` and at `.cookie-comply__modal`.


